### PR TITLE
Added feeds related to the whoishiring bot

### DIFF
--- a/api.py
+++ b/api.py
@@ -96,3 +96,36 @@ class API(object):
         elif include == 'threads':
             tags.append('comment')
         return self._request(','.join(tags))
+
+    def who_is_hiring(self, include='all'):
+        submitted = self.user('whoishiring', 'submitted')
+
+        thread_ids = []
+        for item in submitted.get('hits'):
+            if 'Ask HN: Who is hiring?' in item[u'title'] and ('all' in include or 'jobs' in include):
+                thread_ids.append(item.get('objectID'))
+            elif 'Ask HN: Freelancer? Seeking freelancer?' in item[u'title'] and ('all' in include or 'freelance' in include):
+                thread_ids.append(item.get('objectID'))
+
+        all_hits = []
+        all_responses = {}
+        for thread_id in thread_ids:
+            api = API()
+            api_response = api.comments(story_id=thread_id)
+            if 'hits' in api_response:
+                all_hits.extend(api_response.get('hits'))
+
+            all_responses = merge_two_dicts(api_response, all_responses)
+
+        pseudo_response = {}
+        pseudo_response[u'hits'] = all_hits
+        pseudo_response['link_to'] = None
+
+        return pseudo_response
+
+# TODO - put somewhere else?
+# from: https://stackoverflow.com/questions/38987/how-to-merge-two-dictionaries-in-a-single-expression
+def merge_two_dicts(x, y):
+    z = x.copy()   # start with x's keys and values
+    z.update(y)    # modifies z with y's keys and values & returns None
+    return z

--- a/hnrss.py
+++ b/hnrss.py
@@ -30,6 +30,25 @@ def frontpage():
     rss = RSS(api.frontpage(), rss_title, 'https://news.ycombinator.com/')
     return rss.response()
 
+@app.route('/whoishiring')
+def who_is_hiring():
+    # Get posts by user 'whoishiring'
+    api = API.using_request(request)
+    rss = RSS(api.who_is_hiring(), 'Who is Hiring - All', 'https://news.ycombinator.com/submitted?id=whoishiring')
+    return rss.response()
+
+@app.route('/whoishiring/jobs')
+def who_is_hiring_jobs():
+    api = API.using_request(request)
+    rss = RSS(api.who_is_hiring('jobs'), 'Who is Hiring - Who is Hiring', 'https://news.ycombinator.com/submitted?id=whoishiring')
+    return rss.response()
+
+@app.route('/whoishiring/freelance')
+def who_is_hiring_freelance():
+    api = API.using_request(request)
+    rss = RSS(api.who_is_hiring('freelance'), 'Who is Hiring - Freelance', 'https://news.ycombinator.com/submitted?id=whoishiring')
+    return rss.response()
+
 @app.route('/newcomments')
 def new_comments():
     query = request.args.get('q')


### PR DESCRIPTION
Every month the HN bot [whoishiring](https://news.ycombinator.com/submitted?id=whoishiring) posts two threads that I am interested in:

* Ask HN: Who is hiring? ([most recent here](https://news.ycombinator.com/item?id=15824597))
* Ask HN: Freelancer? Seeking freelancer? ([most recent here](https://news.ycombinator.com/item?id=15824598))

**Use case**
I think the responses to these threads are worthy of their own HNRSS feeds. A job hunter or freelancer with an RSS feedreader can hook it up and search for relevant keywords.

**What is in this Pull Request**
Right now HNRSS can provide a feed of the threads started by the `whoishiring` user. It can also provide a feed of responses to those threads. This Pull Request automates the middle step here which is getting the id of the threads started by `whoishiring` and feeding them to the `comments` endpoint that already exists. Multiple posts by `whoishiring` are merged together to create a feed of responses across all posts.

I have added three endpoints:
* `/whoishiring` - returns an aggregate feed of all thread responses by `whoishiring`
* `/whoishiring/jobs` - returns an aggregate feed of all thread responses to 'Ask HN: Who is hiring?' by `whoishiring`
* `/whoishiring/freelance` - returns an aggregate feed of all thread responses to 'Ask HN: Freelancer? Seeking freelancer? ' by `whoishiring`

Please let me know what you think. Thanks!